### PR TITLE
Naive tokenizer

### DIFF
--- a/run-poc/README.md
+++ b/run-poc/README.md
@@ -179,9 +179,9 @@ Now, let's set up the **text-ingestion pipeline:**
 
    Or better yet (in a third terminal):
 ```
-   echo -e "(observe-text \"this is a another test\" \"any\" 24)" |nc localhost 17005
-   echo -e "(observe-text \"Bernstein () (1876\" \"any\" 24)" |nc localhost 17005
-   echo -e "(observe-text \"Lietuvos žydų kilmės žurnalistas\" \"any\" 24)" |nc localhost 17005
+   echo -e "(observe-text \"this is a another test\")" |nc localhost 17005
+   echo -e "(observe-text \"Bernstein () (1876\")" |nc localhost 17005
+   echo -e "(observe-text \"Lietuvos žydų kilmės žurnalistas\")" |nc localhost 17005
 ```
 
    *Note:* 17005 is the default port for the REPL server in English.

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -99,8 +99,9 @@
 
 (define-public (mst-parse-text-mode plain-text cnt-mode mst-dist)
 
-	; Tokenize the sentence into a list of words.
-	(define word-strs (tokenize-text plain-text))
+	; Assuming input is tokenized, this procedure separates by spaces
+	(define word-strs (string-split plain-text #\ )
+	)
 
 	; Create a sequence of atoms from the sequence of strings.
 	(define word-list (map (lambda (str) (WordNode str)) word-strs))

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -99,8 +99,9 @@
 
 (define-public (mst-parse-text-mode plain-text cnt-mode mst-dist)
 
-	; Assuming input is tokenized, this procedure separates by spaces
-	(define word-strs (string-split plain-text #\ )
+	; Assuming input is tokenized, this procedure separates by spaces 
+	; and adds LEFT-WALL
+	(define word-strs (cons '"###LEFT-WALL###" (string-split plain-text #\ ))
 	)
 
 	; Create a sequence of atoms from the sequence of strings.


### PR DESCRIPTION
Removed the use of ad-hoc tokenizer from MST-parser part of the ULL pipeline. Instead, tokenization is done simply by space splitting, and users can submit pre-tokenized files using any method that they wish.