### PR TITLE
MST-parsing in file mode no longer requires LEFT-WALL

### DIFF
--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -15,8 +15,10 @@
 		(string-split plain-textblock #\newline)
 	)
 
-	; Define current sentence
-	(define current-sentence (car split-textblock))
+	; Define and add LEFT-WALL to current-sentence
+	(define current-sentence 
+		(string-append "###LEFT-WALL### " (car split-textblock))
+	)
 
 	; Assuming input is tokenized, this procedure separates by spaces
 	(define (word-strs text-line)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,18 +17,21 @@ endif(NOT DEFINED ENV{PGUSER})
 SET(ENV{PGPASSWORD} "cheese")
 
 # Reset all test databases needed
-message("\nIf database doesn't exist, dropdb sends error message. Disregard it.")
+message("\nIf database doesn't exist, dropdb sends error message. Disregard it.\n")
 execute_process(COMMAND "dropdb" "ULL_tests")
 execute_process(COMMAND "createdb" "ULL_tests")
 execute_process(COMMAND "psql" "ULL_tests" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
+message("\nCreated database ULL_tests.\n")
 
 execute_process(COMMAND "dropdb" "ULL_calcMI_clique_test")
 execute_process(COMMAND "createdb" "ULL_calcMI_clique_test")
 execute_process(COMMAND "psql" "ULL_calcMI_clique_test" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
+message("\nCreated database ULL_calcMI_clique_test.\n")
 
 execute_process(COMMAND "dropdb" "ULL_calcMI_any_test")
 execute_process(COMMAND "createdb" "ULL_calcMI_any_test")
 execute_process(COMMAND "psql" "ULL_calcMI_any_test" INPUT_FILE "${CMAKE_SOURCE_DIR}/run-poc/atom.sql")
+message("\nCreated database ULL_calcMI_any_test.\n")
 
 # The current ULL pipeline is tokenization-agnostic, so the input
 # should be pre-tokenized by some other method. The pipeline only

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -156,7 +156,7 @@
 (set! mst-dist #f)
 
 (define text-block
-"###LEFT-WALL### Test in file mode\n\
+"Test in file mode\n\
 0 ###LEFT-WALL### 1 Test 2.1\n\
 0 ###LEFT-WALL### 2 in 4.1\n\
 0 ###LEFT-WALL### 3 file 4\n\


### PR DESCRIPTION
For historical reasons, MST-parser in "file" mode needed every sentence to include ###LEFT-WALL### at the beginning. However, to be consistent with other modes, the LW should be added by the parser itself, and an ad-hoc script to add the LW token had even been created. 
This PR fixes the situation by removing the requirement. Unit tests are adapted accordingly.