### PR TITLE
Pass sentences to cogserver using socket (no netcat)

### DIFF
--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -77,7 +77,14 @@ if [[ $? -ne 0 ]] ; then
 	exit 1
 fi
 
+if [ -f "mst-parses.ull" ];
+then
+   # Sort parses and remove index, convert to ull format
+   sort -g mst-parses.ull | cut -f2- | tr '\t' '\n';
+   # Organize parse file
+   mv mst-parses.ull "$parsesdir/${rest}.ull";
+fi
+
 # Move article to the done-queue
-mv mst-parses.ull "$parsesdir/${rest}.ull"
 mv "$splitdir/$rest" "$subdir/$rest"
 rm "$base/$rest"

--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -77,12 +77,12 @@ if [[ $? -ne 0 ]] ; then
 	exit 1
 fi
 
-if [ -f "mst-parses.ull" ];
-then
+if [ -f "mst-parses.ull" ]; then
    # Sort parses and remove index, convert to ull format
-   sort -g mst-parses.ull | cut -f2- | tr '\t' '\n';
+   sort -g mst-parses.ull | cut -f2- | tr '\t' '\n' > mst-parses.ull_ordered;
    # Organize parse file
-   mv mst-parses.ull "$parsesdir/${rest}.ull";
+   mv mst-parses.ull_ordered "$parsesdir/${rest}.ull";
+   rm mst-parses.ull
 fi
 
 # Move article to the done-queue

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -145,7 +145,7 @@
 	(mst-parse-text-mode plain-text "any" #f))
 
 ; ---------------------------------------------------------------------
-(define (export-mst-parse plain-text mstparse filename)
+(define (export-mst-parse plain-text mstparse SENT-NBR filename)
 "
   Export an MST-parse to a text file named filename,
   so that parses can be examined.
@@ -186,10 +186,11 @@
 		(lambda (l1 l2)
 			(< (get-lindex l1) (get-lindex l2))))
 
-	; Print the sentence first
+	; Print the numbered sentence first
 	(if (not (null? plain-text))
 		(display
-			(format #f "~a\n"
+			(format #f "~a\t~a\t"
+				SENT-NBR
 				plain-text)
 			file-port))
 
@@ -198,7 +199,7 @@
 		(lambda (l) ; links
 			(if (> (get-mi l) -1.0e10) ; bad-MI
 				(display
-					(format #f "~a ~a ~a ~a ~a\n"
+					(format #f "~a ~a ~a ~a ~a\t"
 						(get-lindex l)
 						(get-lword l)
 						(get-rindex l)
@@ -214,7 +215,7 @@
 	(close-port file-port)
 )
 
-(define-public (observe-mst-mode plain-text CNT-MODE MST-DIST EXPORT-MST)
+(define-public (observe-mst-mode plain-text SENT-NBR CNT-MODE MST-DIST EXPORT-MST)
 "
   observe-mst-mode -- update pseduo-disjunct counts by observing raw text.
 					  Build mst-parses using MI calculated beforehand.
@@ -242,8 +243,8 @@
 	)
 	(if EXPORT-MST
 		(if file-cnt-mode
-			(export-mst-parse (car (string-split plain-text #\newline)) parse "mst-parses.ull")
-			(export-mst-parse plain-text parse "mst-parses.ull")
+			(export-mst-parse (car (string-split plain-text #\newline)) parse SENT-NBR "mst-parses.ull")
+			(export-mst-parse plain-text parse SENT-NBR "mst-parses.ull")
 		)
 	)
 
@@ -252,5 +253,5 @@
 
 ; Wrapper for backwards compatibility
 (define-public (observe-mst plain-text)
-	(observe-mst-mode plain-text "any" #f #f)
+	(observe-mst-mode plain-text "any" 1 #f #f)
 )

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -5,7 +5,7 @@
 # Submit a collection of sentences, one sentence at a time, to the
 # cogserver located on host ARGV[0] and port ARGV[1].  The sentences
 # are read from standard input, and must be arranged with one sentence
-# per line. The are sent to the cogserver using ARGV[2] as the command.
+# per line. They are sent to the cogserver using ARGV[2] as the command.
 # For word-pair counting, ARGV[2] is "observe-text-mode"
 # For disjunct counting, ARGV[2] is "observe-mst-mode"
 # ARGV[3] and ARGV[4] (and ARGV[5] for observe-mst-mode) are necessary
@@ -17,7 +17,13 @@
 
 die "Wrong number of args!" if ($#ARGV < 4);
 
-# Avoid using netcat.
+# Use netcat only for pair-counting, not for mst-parsing (this may cause
+# problems if we care about disjunct counting, but for now we don't care
+# about them)
+# Verify that the host and port number are OK.
+`nc -z $ARGV[0] $ARGV[1]`;
+die "Netcat failed! Bad host or port?" if (0 != $?);
+my $netcat = "|nc $ARGV[0] $ARGV[1]";
 
 use Socket;
 my $port =  "$ARGV[1]";
@@ -85,7 +91,9 @@ else
 		chop;
 
 		if ( $ARGV[2] eq "observe-text-mode" )
-			{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
+			{open NC, $netcat || die "nc failed: $!\n";
+ 			print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"; }
+			#{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
 			{ $sent_nbr += 1;
 			send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -57,6 +57,7 @@ sub send_stuff {
 }
 
 my $start_time = time();
+my $sent_nbr = 0;
 
 if ($ARGV[3] eq "file")
 {
@@ -86,7 +87,8 @@ else
 		if ( $ARGV[2] eq "observe-text-mode" )
 			{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
-			{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
+			{ $sent_nbr += 1;
+			send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
 		my $elapsed = time() - $start_time;
 		print "submit-one (elapsed $elapsed): $_\n";
 	}

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -72,7 +72,8 @@ if ($ARGV[3] eq "file")
 	{
 		if (/^\n$/) {
 			chomp($buffer);
-			send_stuff("($ARGV[2] \"$buffer\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n");
+			$sent_nbr += 1;
+			send_stuff("($ARGV[2] \"$buffer\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n");
 			my $elapsed = time() - $start_time;
 			print "submit-one (elapsed $elapsed): $_\n";
 			$buffer="";

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -5,12 +5,7 @@
 # Submit a collection of sentences, one sentence at a time, to the
 # cogserver located on host ARGV[0] and port ARGV[1].  The sentences
 # are read from standard input, and must be arranged with one sentence
-# per line.
-# For the "file" mode, where word-instance-pair weights are read from a file, 
-# the input must be arranged in blocks starting with 
-# one sentence, and followed by the word-pairs and their weights, one pair
-# per line.  
-# They are sent to the cogserver using ARGV[2] as the command.
+# per line. The are sent to the cogserver using ARGV[2] as the command.
 # For word-pair counting, ARGV[2] is "observe-text-mode"
 # For disjunct counting, ARGV[2] is "observe-mst-mode"
 # ARGV[3] and ARGV[4] (and ARGV[5] for observe-mst-mode) are necessary
@@ -22,11 +17,44 @@
 
 die "Wrong number of args!" if ($#ARGV < 4);
 
-# Verify that the host and port number are OK.
-`nc -z $ARGV[0] $ARGV[1]`;
-die "Netcat failed! Bad host or port?" if (0 != $?);
+# Avoid using netcat.
 
-my $netcat = "|nc $ARGV[0] $ARGV[1]";
+use Socket;
+my $port =  "$ARGV[1]";
+my $server = "$ARGV[0]";
+
+# Don't use netcat; just send directly
+# argument 1: what to send (ascii string)
+# argument 2: bool flag, wait for response, or not.
+sub send_stuff {
+	socket(SOCKET, PF_INET, SOCK_STREAM, (getprotobyname('tcp'))[2])
+		or die "Can't create a socket $!\n";
+
+	connect(SOCKET, pack_sockaddr_in($port, inet_aton($server)))
+		or die "Can't connect to port $port! \n";
+
+	my $text = $_[0];
+
+	# if subroutine has second argument, use it.
+	my $wait_for_response = 0;
+	if (1 < scalar @_) {
+		$wait_for_response = $_[1];
+	}
+	# print "Will wait for response: $wait_for_response\n";
+
+	if ($wait_for_response) {
+		SOCKET->autoflush(1);
+		print SOCKET "$text\n.\n.\n";
+		my $line;
+		while ($line = <SOCKET>) {
+			# print "Drained: $line";
+		}
+		close SOCKET;
+	} else {
+		print SOCKET "$text\n.\n.\n";
+		close SOCKET;
+	}
+}
 
 my $start_time = time();
 
@@ -37,8 +65,7 @@ if ($ARGV[3] eq "file")
 	{
 		if (/^\n$/) {
 			chomp($buffer);
-			open NC, $netcat || die "nc failed: $!\n";
-			print NC "($ARGV[2] \"$buffer\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n";
+			send_stuff("($ARGV[2] \"$buffer\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n");
 			my $elapsed = time() - $start_time;
 			print "submit-one (elapsed $elapsed): $_\n";
 			$buffer="";
@@ -53,15 +80,13 @@ else
 {
 	while (<STDIN>)
 	{
-		if (/<P>/) { next; }
+		if (/^\n$/) { next; }
 		chop;
 
-		# open(NC, "|nc localhost 17002") || die "nc failed: $!\n";
-		open NC, $netcat || die "nc failed: $!\n";
 		if ( $ARGV[2] eq "observe-text-mode" )
-			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"; }
+			{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
-			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"; }
+			{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
 		my $elapsed = time() - $start_time;
 		print "submit-one (elapsed $elapsed): $_\n";
 	}

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -101,4 +101,5 @@ else
 		print "submit-one (elapsed $elapsed): $_\n";
 	}
 }
+sleep 5 ; # Small delay to allow socket processes to finish
 print "Done with article.\n";

--- a/run-poc/text-process.sh
+++ b/run-poc/text-process.sh
@@ -31,6 +31,4 @@ esac
 source ./config/det-port-num.sh $1 $2
 
 # Process files in assigned directory
-echo "ANTES"
 time find $directory -type f -exec ./process-one.sh $1 $2 {} localhost $PORT \;
-echo "DESPUES"

--- a/run-poc/text-process.sh
+++ b/run-poc/text-process.sh
@@ -31,4 +31,6 @@ esac
 source ./config/det-port-num.sh $1 $2
 
 # Process files in assigned directory
+echo "ANTES"
 time find $directory -type f -exec ./process-one.sh $1 $2 {} localhost $PORT \;
+echo "DESPUES"

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -65,8 +65,8 @@
 )
 
 ; Parse the sentences
-(define parse-1 (observe-mst-mode test-str-1 cnt-mode mst-dist #f))
-(define parse-2 (observe-mst-mode test-str-2 cnt-mode mst-dist #f))
+(define parse-1 (observe-mst-mode test-str-1 1 cnt-mode mst-dist #f))
+(define parse-2 (observe-mst-mode test-str-2 1 cnt-mode mst-dist #f))
 
 ; manually calculated, expected parses
 (define w1 (cons 1 (WordNode "###LEFT-WALL###")))
@@ -117,8 +117,8 @@
 )
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode test-str-1 cnt-mode mst-dist #f))
-(set! parse-2 (observe-mst-mode test-str-2 cnt-mode mst-dist #f))
+(set! parse-1 (observe-mst-mode test-str-1 1 cnt-mode mst-dist #f))
+(set! parse-2 (observe-mst-mode test-str-2 1 cnt-mode mst-dist #f))
 
 ; manually calculated, expected parses
 (set! w3 (cons 3 (WordNode "first")))
@@ -169,7 +169,7 @@
 3 file 4 mode 2")
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode text-block cnt-mode mst-dist #f))
+(set! parse-1 (observe-mst-mode text-block 1 cnt-mode mst-dist #f))
 
 ; manually calculated, expected parses (note that current heuristic doesn't
 ; give us the actual MST parse, but a close one)


### PR DESCRIPTION
For MST-parsing, sentences to parse are sent using a direct socket connection instead of netcat. 
Due to netcat waiting too long for a response (see issue https://github.com/singnet/language-learning/issues/179), this change improves processing speed substantially.
Same idea cannot be applied to pair-counting as it is now, because database writing is not thread safe, and  word-pairs are counted incorrectly. 