### PR TITLE
Implemented "hybrid parser" that accounts for distance between word-instances

### DIFF
--- a/run-poc/config/params.txt
+++ b/run-poc/config/params.txt
@@ -3,7 +3,7 @@
 
 export cnt_mode="file" 	 # clique, clique-dist, any, or file
 export cnt_reach=6		 # num-parses for any, or win-size for cliques
-export mst_dist="#f"		 # #t or #f; use distance weight during mst
+export mst_dist=(1 1 1 1)	# distance multipliers for pair-weight during mst
 export exp_parses="#t"  	 # #t or #f; exports parses in folder mst-parses
 export split_sents="#f"		 # #t or #f; calls sentence splitter before parser
 #TODO export store_fmi="#t"	# #t or #f 

--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -22,7 +22,7 @@ parsesdir=mst-parses
 # Default parameter values
 cnt_mode="clique-dist"
 cnt_reach=6
-mst_dist="#t"
+mst_dist=(1)
 exp_parses="#t"
 split_sents="#t"
 source ./config/params.txt # overrides default values, if present
@@ -45,7 +45,7 @@ case $1 in
          # create parses directory if missing
          mkdir -p $(dirname "$parsesdir/$rest")
       fi
-      params="$cnt_mode $mst_dist $exp_parses"
+      params="$cnt_mode ${mst_dist[@]} $exp_parses"
       ;;
 esac
 

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -86,16 +86,8 @@
 	; longer than 16. This is a sharp cutoff.
 	; This causes parser to run at O(N^3) for LEN < 16 and
 	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	; Otherwise, assign modification to scorer depending on
-	; mst-parsing mode. If mst-distance accounting is activated
-	; shift all mi-values by 1/LEN, where LEN is the difference
-	; in positions in a sentence between words in word-pair.
 	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN)
-			-2e25
-			(let
-				((modifier (if mst-dist (/ 1 LEN) 0)))
-				(+ modifier (scorer LW RW LEN)))))
+		(if (< 16 LEN) -2e25 (scorer LW RW LEN)))
 
 	; Entry point, call parser on atomized sentence with ad-hoc scorer
 	(mst-parse-atom-seq (word-list (word-strs current-sentence)) trunc-scorer)

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -6,7 +6,7 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
-(define-public (mst-parse-text-file plain-textblock mst-dist)
+(define-public (mst-parse-text-file plain-textblock mst-dist DIST-MOD)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
 "
@@ -67,14 +67,18 @@
 	)	
 
 	; Define scoring function to look for values in weights-array.
-	; Scorer lambda function should store weights-array from its
+	; Scorer lambda function should refer to weights-array from its
 	; current environment (array was defined above).
+	; Scoring function considers weight multipliers coming from DIST-MOD
 	(define scorer 
 		(lambda (left-atom right-atom distance)
 			(define left-index (inexact->exact (string->number (cog-name (gdr left-atom)))))
 			(define right-index (inexact->exact (string->number (cog-name (gdr right-atom)))))
+			; modifier values are given in DIST-MOD. If distance is longer than 
+			; what has been defined in the array, use last array value:
+			(define modifier (list-ref DIST-MOD (min distance (length DIST-MOD))))
 
-			(array-ref weights-array left-index right-index)
+			(* modifier (array-ref weights-array left-index right-index))
 		)
 	)
 

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -6,7 +6,7 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
-(define-public (mst-parse-text-file plain-textblock mst-dist DIST-MOD)
+(define-public (mst-parse-text-file plain-textblock DIST-MOD)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
 "
@@ -76,7 +76,7 @@
 			(define right-index (inexact->exact (string->number (cog-name (gdr right-atom)))))
 			; modifier values are given in DIST-MOD. If distance is longer than 
 			; what has been defined in the array, use last array value:
-			(define modifier (list-ref DIST-MOD (min distance (length DIST-MOD))))
+			(define modifier (list-ref DIST-MOD (- (min distance (length DIST-MOD)) 1)))
 
 			(* modifier (array-ref weights-array left-index right-index))
 		)
@@ -227,6 +227,7 @@
 			(mst-parse-text-mode plain-text CNT-MODE MST-DIST)
 		)
 	)
+	(display parse)
 
 	; The count-one-atom function fetches from the SQL database,
 	; increments the count by one, and stores the result back

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -6,6 +6,7 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
+
 (define-public (mst-parse-text-file plain-textblock DIST-MOD)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
@@ -82,12 +83,7 @@
 		)
 	)
 
-	; Assign a bad cost to links that are too long --
-	; longer than 16. This is a sharp cutoff.
-	; This causes parser to run at O(N^3) for LEN < 16 and
-	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN) -2e25 (scorer LW RW LEN)))
+	(define trunc-scorer (make-trunc-scorer scorer))
 
 	; Entry point, call parser on atomized sentence with ad-hoc scorer
 	(mst-parse-atom-seq (word-list (word-strs current-sentence)) trunc-scorer)
@@ -241,7 +237,7 @@
 			(export-mst-parse plain-text parse "mst-parses.ull")
 		)
 	)
-	
+
 	parse; return the parse, for unit-test purposes
 )
 

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -210,7 +210,6 @@
 			(mst-parse-text-mode plain-text CNT-MODE MST-DIST)
 		)
 	)
-	(display parse)
 
 	; The count-one-atom function fetches from the SQL database,
 	; increments the count by one, and stores the result back

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -113,20 +113,7 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
-	; Assign a bad cost to links that are too long --
-	; longer than 16. This is a sharp cutoff.
-	; This causes parser to run at O(N^3) for LEN < 16 and
-	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	; Otherwise, assign modification to scorer depending on
-	; mst-parsing mode. If mst-distance accounting is activated
-	; shift all mi-values by 1/LEN, where LEN is the difference
-	; in positions in a sentence between words in word-pair.
-	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN)
-			-2e25
-			(let
-				((modifier (if mst-dist (/ 1 LEN) 0)))
-				(+ modifier (scorer LW RW LEN)))))
+	(define trunc-scorer (make-trunc-scorer scorer))
 
 	; Process the list of words.
 	(mst-parse-atom-seq word-list trunc-scorer)

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -7,7 +7,7 @@
 ; is returned.
 ;
 
-(define-public (mst-parse-text-file plain-textblock DIST-MOD)
+(define-public (mst-parse-text-file plain-textblock DIST-MULT)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
 "
@@ -70,14 +70,14 @@
 	; Define scoring function to look for values in weights-array.
 	; Scorer lambda function should refer to weights-array from its
 	; current environment (array was defined above).
-	; Scoring function considers weight multipliers coming from DIST-MOD
+	; Scoring function considers weight multipliers coming from DIST-MULT
 	(define scorer 
 		(lambda (left-atom right-atom distance)
 			(define left-index (inexact->exact (string->number (cog-name (gdr left-atom)))))
 			(define right-index (inexact->exact (string->number (cog-name (gdr right-atom)))))
-			; modifier values are given in DIST-MOD. If distance is longer than 
+			; modifier values are given in DIST-MULT. If distance is longer than 
 			; what has been defined in the array, use last array value:
-			(define modifier (list-ref DIST-MOD (- (min distance (length DIST-MOD)) 1)))
+			(define modifier (list-ref DIST-MULT (- (min distance (length DIST-MULT)) 1)))
 
 			(* modifier (array-ref weights-array left-index right-index))
 		)
@@ -91,7 +91,7 @@
 )
 
 
-(define-public (mst-parse-text-mode plain-text cnt-mode mst-dist)
+(define-public (mst-parse-text-mode plain-text cnt-mode DIST-MULT)
 
 	; Assuming input is tokenized, this procedure separates by spaces 
 	; and adds LEFT-WALL
@@ -111,7 +111,7 @@
 
 	(define mi-source (add-pair-freq-api pair-obj))
 
-	(define scorer (make-score-fn mi-source 'pair-fmi))
+	(define scorer (make-score-fn-dist mi-source 'pair-fmi DIST-MULT))
 
 	(define trunc-scorer (make-trunc-scorer scorer))
 
@@ -198,7 +198,7 @@
   observe-mst-mode -- update pseduo-disjunct counts by observing raw text.
   
   Build mst-parses using MI calculated beforehand.
-  When MST-DIST is true, word-pair MI values are adjusted for distance.
+  Values in MST-DIST adjust word-pair weight values for distance.
   Obtained parses are exported to file if EXPORT-MST is true.
   This is the second part of the learning algo: simply count how
   often pseudo-disjuncts show up.

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -241,6 +241,8 @@
 			(export-mst-parse plain-text parse "mst-parses.ull")
 		)
 	)
+	
+	parse; return the parse, for unit-test purposes
 )
 
 ; Wrapper for backwards compatibility

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -106,7 +106,7 @@ else
  			# print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"; }
 			#{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
-			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"; }
+			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" '(${ARGV[@]}) $ARGV[5])\n"; }
 			#{ $sent_nbr += 1;
 			#send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
 		my $elapsed = time() - $start_time;

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -21,6 +21,7 @@
 #
 
 die "Wrong number of args!" if ($#ARGV < 4);
+my @dist_mult = @ARGV[4..$#ARGV-1];
 
 # Use netcat only for pair-counting, not for mst-parsing (this may cause
 # problems if we care about disjunct counting, but for now we don't care
@@ -78,7 +79,7 @@ if ($ARGV[3] eq "file")
 		if (/^\n$/) {
 			chomp($buffer);
 			open NC, $netcat || die "nc failed: $!\n";
-			print NC "($ARGV[2] \"$buffer\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n";
+			print NC "($ARGV[2] \"$buffer\" \"$ARGV[3]\" '(@dist_mult) $ARGV[5])\n";
 			# $sent_nbr += 1;
 			# send_stuff("($ARGV[2] \"$buffer\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n");
 			my $elapsed = time() - $start_time;
@@ -106,7 +107,7 @@ else
  			# print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"; }
 			#{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
-			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" '(${ARGV[@]}) $ARGV[5])\n"; }
+			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" '(@dist_mult) $ARGV[5])\n"; }
 			#{ $sent_nbr += 1;
 			#send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
 		my $elapsed = time() - $start_time;

--- a/scm/mst-parser.scm
+++ b/scm/mst-parser.scm
@@ -200,7 +200,7 @@
 ; longer than 16. This is a sharp cutoff.
 ; This causes parser to run at O(N^3) for LEN < 16 and
 ; a faster rate, O(N^2.3) for 16<LEN. This should help.
-(define (make-trunc-scorer scorer)
+(define-public (make-trunc-scorer scorer)
 	(lambda (LW RW LEN)
 		(if (< 16 LEN) -2e25 (scorer LW RW LEN))))
 

--- a/scm/mst-parser.scm
+++ b/scm/mst-parser.scm
@@ -195,6 +195,15 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
+
+; Assign a bad cost to links that are too long --
+; longer than 16. This is a sharp cutoff.
+; This causes parser to run at O(N^3) for LEN < 16 and
+; a faster rate, O(N^2.3) for 16<LEN. This should help.
+(define (make-trunc-scorer scorer)
+	(lambda (LW RW LEN)
+		(if (< 16 LEN) -2e25 (scorer LW RW LEN))))
+
 (define-public (mst-parse-text plain-text)
 
 	; Tokenize the sentence into a list of words.
@@ -211,12 +220,7 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
-	; Assign a bad cost to links that are too long --
-	; longer than 16. This is a sharp cutoff.
-	; This causes parser to run at O(N^3) for LEN < 16 and
-	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN) -2e25 (scorer LW RW LEN)))
+	(define trunc-scorer (make-trunc-scorer scorer))
 
 	; Process the list of words.
 	(mst-parse-atom-seq word-list trunc-scorer)

--- a/scm/mst-parser.scm
+++ b/scm/mst-parser.scm
@@ -195,15 +195,6 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
-
-; Assign a bad cost to links that are too long --
-; longer than 16. This is a sharp cutoff.
-; This causes parser to run at O(N^3) for LEN < 16 and
-; a faster rate, O(N^2.3) for 16<LEN. This should help.
-(define-public (make-trunc-scorer scorer)
-	(lambda (LW RW LEN)
-		(if (< 16 LEN) -2e25 (scorer LW RW LEN))))
-
 (define-public (mst-parse-text plain-text)
 
 	; Tokenize the sentence into a list of words.
@@ -220,7 +211,12 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
-	(define trunc-scorer (make-trunc-scorer scorer))
+	; Assign a bad cost to links that are too long --
+	; longer than 16. This is a sharp cutoff.
+	; This causes parser to run at O(N^3) for LEN < 16 and
+	; a faster rate, O(N^2.3) for 16<LEN. This should help.
+	(define (trunc-scorer LW RW LEN)
+		(if (< 16 LEN) -2e25 (scorer LW RW LEN)))
 
 	; Process the list of words.
 	(mst-parse-atom-seq word-list trunc-scorer)

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -43,9 +43,9 @@
 ; Begin test
 (test-begin suite-name)
 
-; First mode to check: clique, without mst-distance
+; First mode to check: clique, without mst distance multipliers
 (define cnt-mode "clique")
-(define mst-dist #f)
+(define dist-mult '(1))
 
 (define word-pair-atoms (make-word-pair-list cnt-mode))
 
@@ -65,8 +65,8 @@
 )
 
 ; Parse the sentences
-(define parse-1 (observe-mst-mode test-str-1 cnt-mode mst-dist #f))
-(define parse-2 (observe-mst-mode test-str-2 cnt-mode mst-dist #f))
+(define parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult #f))
+(define parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult #f))
 
 ; manually calculated, expected parses
 (define w1 (cons 1 (WordNode "###LEFT-WALL###")))
@@ -96,15 +96,15 @@
 )
 
 ; Test that MST-parses are as expected
-(define check-MST-text "Checking MST-parses: 'clique' mode, no mst-dist")
+(define check-MST-text "Checking MST-parses: 'clique' mode, no dist-mult")
 (test-assert check-MST-text (equal? parse-1 expected-parse-1))
 (test-assert check-MST-text (equal? parse-2 expected-parse-2))
 
 ; -------------------------------------------------
-; Second mode to check: any, with mst-distance
+; Second mode to check: any, with dist-mult
 ; any doesn't change the MST-parser, just testing option works
 (set! cnt-mode "any")
-(set! mst-dist #t)
+(set! dist-mult '(1 0.5 0.1)) ; currently fails, need to update results
 
 (set! word-pair-atoms (make-word-pair-list cnt-mode))
 
@@ -117,8 +117,8 @@
 )
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode test-str-1 cnt-mode mst-dist #f))
-(set! parse-2 (observe-mst-mode test-str-2 cnt-mode mst-dist #f))
+(set! parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult #f))
+(set! parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult #f))
 
 ; manually calculated, expected parses
 (set! w3 (cons 3 (WordNode "first")))
@@ -146,14 +146,14 @@
 )
 
 ; Test that MST-parses are as expected
-(define check-MST-text "Checking MST-parses: 'any' mode with mst-dist")
+(define check-MST-text "Checking MST-parses: 'any' mode with dist-mult")
 (test-assert check-MST-text (equal? parse-1 expected-parse-1))
 (test-assert check-MST-text (equal? parse-2 expected-parse-2))
 
 ; -------------------------------------------------
-; Third mode to check: file, no mst-distance
+; Third mode to check: file, no mst distance multipliers
 (set! cnt-mode "file")
-(set! mst-dist '(1 1))
+(set! dist-mult '(1 1))
 
 (define text-block
 "Test in file mode\n\
@@ -169,7 +169,7 @@
 3 file 4 mode 2")
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode text-block cnt-mode mst-dist #f))
+(set! parse-1 (observe-mst-mode text-block cnt-mode dist-mult #f))
 
 ; manually calculated, expected parses (note that current heuristic doesn't
 ; give us the actual MST parse, but a close one)
@@ -194,7 +194,7 @@
 )
 
 ; Test that MST-parses are as expected
-(define check-MST-text "Checking MST-parses: 'file' mode, no mst-dist")
+(define check-MST-text "Checking MST-parses: 'file' mode, no dist-mult")
 (test-assert check-MST-text (equal? parse-1 expected-parse-1))
 
 ; -------------------------------------------------

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -151,7 +151,8 @@
 (test-assert check-MST-text (equal? parse-2 expected-parse-2))
 
 ; -------------------------------------------------
-; Third mode to check: file, no mst distance multipliers
+; Third mode to check: file 
+; First test: no mst distance multipliers
 (set! cnt-mode "file")
 (set! dist-mult '(1 1))
 
@@ -171,10 +172,10 @@
 ; Parse the sentences
 (set! parse-1 (observe-mst-mode text-block cnt-mode dist-mult #f))
 
-; manually calculated, expected parses (note that current heuristic doesn't
-; give us the actual MST parse, but a close one)
-; atoms in "file" mode mst-parser have a different structure, needed
-; to retain the word positions in the sentece
+; Manually calculated, expected parses (note that current heuristic doesn't
+; give us the actual MST parse, but a close one).
+; Atoms in "file" mode mst-parser have a different structure from other modes,
+; needed to retain the word positions in the sentece.
 (set! w1 (cons 1 (WordSequenceLink (WordNode "###LEFT-WALL###") (NumberNode 0))))
 (set! w2 (cons 2 (WordSequenceLink (WordNode "Test") (NumberNode 1))))
 (set! w3 (cons 3 (WordSequenceLink (WordNode "in") (NumberNode 2))))
@@ -196,6 +197,30 @@
 ; Test that MST-parses are as expected
 (define check-MST-text "Checking MST-parses: 'file' mode, no dist-mult")
 (test-assert check-MST-text (equal? parse-1 expected-parse-1))
+
+; Second test: mst-distance multipliers
+(set! dist-mult '(1 0.5))
+
+; Parse the sentences
+(set! parse-2 (observe-mst-mode text-block cnt-mode dist-mult #f))
+
+; Manually calculated, expected parses
+(define expected-parse-2
+	(append
+		(append 
+			(append 
+				(list (cons (cons w2 w5) 2.5))
+				(list (cons (cons w1 w2) 2.1))
+			)
+			(list (cons (cons w2 w3) 2.05))
+		)
+		(list (cons (cons w4 w5) 2))
+	)
+)
+
+; Test that MST-parses are as expected
+(define check-MST-text "Checking MST-parses: 'file' mode, w/dist-mult")
+(test-assert check-MST-text (equal? parse-2 expected-parse-2))
 
 ; -------------------------------------------------
 ; Close testing database and suite

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -104,7 +104,7 @@
 ; Second mode to check: any, with dist-mult
 ; any doesn't change the MST-parser, just testing option works
 (set! cnt-mode "any")
-(set! dist-mult '(1 0.5 0.1)) ; currently fails, need to update results
+(set! dist-mult '(1 0.5 0.1))
 
 (set! word-pair-atoms (make-word-pair-list cnt-mode))
 

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -153,7 +153,7 @@
 ; -------------------------------------------------
 ; Third mode to check: file, no mst-distance
 (set! cnt-mode "file")
-(set! mst-dist #f)
+(set! mst-dist '(1 1))
 
 (define text-block
 "Test in file mode\n\

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -126,10 +126,10 @@
 (define expected-parse-1
 	(append 
 		(append 
-			(list (cons (cons w3 w4) (+ (log2 5) 1)))
-			(list (cons (cons w2 w3) (+ (- (log2 5) 2) 1)))
+			(list (cons (cons w3 w4) (log2 5)))
+			(list (cons (cons w2 w3) (- (log2 5) 2)))
 		)
-		(list (cons (cons w1 w2) (+ (- (log2 5) 1) 1)))
+		(list (cons (cons w1 w2) (- (log2 5) 1)))
 	)
 )
 
@@ -138,10 +138,10 @@
 (define expected-parse-2
 	(append 
 		(append 
-			(list (cons (cons w1 w2) (+ (- (log2 5) 1) 1)))
-			(list (cons (cons w2 w3) 2.1))
+			(list (cons (cons w1 w2) (- (log2 5) 1)))
+			(list (cons (cons w2 w3) 1.1))
 		)
-		(list (cons (cons w2 w4) 1.9))
+		(list (cons (cons w3 w4) 0.8))
 	)
 )
 


### PR DESCRIPTION
Implemented request from issue https://github.com/singnet/language-learning/issues/217 (approach B):

MST-parser takes an optional list parameter that contains multipliers to assign to word-instance weights, depending on their separation in a sentences. Parameter "mst_dist" is specified in run-poc/config/params.txt file; it's a list of values (f(1) f(2) f(3) .. f(n)) defined in issue 217.

In this implementation, for x > n (n being the last value in the list parameter), f(x) = f(n)