### PR TITLE
Pass parse output filename as parameter

### DIFF
--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -22,7 +22,7 @@ parsesdir=mst-parses
 # Default parameter values
 cnt_mode="clique-dist"
 cnt_reach=6
-mst_dist="#t"
+mst_dist=(1)
 exp_parses="#t"
 split_sents="#t"
 source ./config/params.txt # overrides default values, if present

--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -22,7 +22,7 @@ parsesdir=mst-parses
 # Default parameter values
 cnt_mode="clique-dist"
 cnt_reach=6
-mst_dist=(1)
+mst_dist="#t"
 exp_parses="#t"
 split_sents="#t"
 source ./config/params.txt # overrides default values, if present
@@ -41,11 +41,13 @@ case $1 in
    mst)
       subdir=mst-articles
       observe="observe-mst-mode"
-      if [[ "$exp_parses" == "#t" ]]; then
+      if [[ "$exp_parses" != "#f" ]]; then
          # create parses directory if missing
-         mkdir -p $(dirname "$parsesdir/$rest")
+         mkdir -p $(dirname "$parsesdir/$rest");
+         params="$cnt_mode $mst_dist ${rest}.ull"; # pass parses filename
+      else
+         params="$cnt_mode $mst_dist $exp_parses"; # don't print parses
       fi
-      params="$cnt_mode ${mst_dist[@]} $exp_parses"
       ;;
 esac
 
@@ -77,13 +79,12 @@ if [[ $? -ne 0 ]] ; then
 	exit 1
 fi
 
-if [ -f "mst-parses.ull" ]; then
+if [ -f "${rest}.ull" ]; then
    # Sort parses and remove index, convert to ull format
-   # sort -g mst-parses.ull | cut -f2- | tr '\t' '\n' > mst-parses.ull_ordered;
+   sort -g "${rest}.ull" | cut -f2- | tr '\t' '\n' > "${rest}.ull_ordered";
    # Organize parse file
-   # mv mst-parses.ull_ordered "$parsesdir/${rest}.ull";
-   # rm mst-parses.ull
-   mv mst-parses.ull "$parsesdir/${rest}.ull"
+   mv "${rest}.ull_ordered" "$parsesdir/${rest}.ull";
+   rm "${rest}.ull"
 fi
 
 # Move article to the done-queue

--- a/run-poc/process-one.sh
+++ b/run-poc/process-one.sh
@@ -81,10 +81,11 @@ fi
 
 if [ -f "${rest}.ull" ]; then
    # Sort parses and remove index, convert to ull format
-   sort -g "${rest}.ull" | cut -f2- | tr '\t' '\n' > "${rest}.ull_ordered";
+   # sort -g "${rest}.ull" | cut -f2- | tr '\t' '\n' > "${rest}.ull_ordered";
    # Organize parse file
-   mv "${rest}.ull_ordered" "$parsesdir/${rest}.ull";
-   rm "${rest}.ull"
+   # mv "${rest}.ull_ordered" "$parsesdir/${rest}.ull";
+   # rm "${rest}.ull"
+   mv ${rest}.ull "$parsesdir/${rest}.ull"
 fi
 
 # Move article to the done-queue

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -6,7 +6,25 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
-(define-public (mst-parse-text-file plain-textblock mst-dist)
+
+; Create a distance-modified scorer function:
+; The list DIST-MULTS contains multipliers for the score for each
+; possible integer distance between the atoms. For distances longer 
+; than the range of the list, the list's last value is used as multiplier.
+; Also: assign a bad cost to links that are too long --
+; longer than 16. This is a sharp cutoff.
+; This causes parser to run at O(N^3) for LEN < 16 and
+; a faster rate, O(N^2.3) for 16<LEN. This should help.
+(define (make-distance-scorer scorer DIST-MULTS)
+	(lambda (LW RW LEN)
+		; take distance-multiplier from DIST-MULT list
+		(define multiplier (list-ref DIST-MULTS (- (min LEN (length DIST-MULTS)) 1)))
+
+		(if (< 16 LEN) -2e25 (* multiplier (scorer LW RW LEN)))
+	)
+)
+
+(define-public (mst-parse-text-file plain-textblock DIST-MULT)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
 "
@@ -67,7 +85,7 @@
 	)	
 
 	; Define scoring function to look for values in weights-array.
-	; Scorer lambda function should store weights-array from its
+	; Scorer lambda function should refer to weights-array from its
 	; current environment (array was defined above).
 	(define scorer 
 		(lambda (left-atom right-atom distance)
@@ -78,28 +96,15 @@
 		)
 	)
 
-	; Assign a bad cost to links that are too long --
-	; longer than 16. This is a sharp cutoff.
-	; This causes parser to run at O(N^3) for LEN < 16 and
-	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	; Otherwise, assign modification to scorer depending on
-	; mst-parsing mode. If mst-distance accounting is activated
-	; shift all mi-values by 1/LEN, where LEN is the difference
-	; in positions in a sentence between words in word-pair.
-	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN)
-			-2e25
-			(let
-				((modifier (if mst-dist (/ 1 LEN) 0)))
-				(+ modifier (scorer LW RW LEN)))))
+	(define dist-scorer (make-distance-scorer scorer DIST-MULT))
 
 	; Entry point, call parser on atomized sentence with ad-hoc scorer
-	(mst-parse-atom-seq (word-list (word-strs current-sentence)) trunc-scorer)
+	(mst-parse-atom-seq (word-list (word-strs current-sentence)) dist-scorer)
 
 )
 
 
-(define-public (mst-parse-text-mode plain-text cnt-mode mst-dist)
+(define-public (mst-parse-text-mode plain-text cnt-mode DIST-MULT)
 
 	; Assuming input is tokenized, this procedure separates by spaces 
 	; and adds LEFT-WALL
@@ -121,23 +126,10 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
-	; Assign a bad cost to links that are too long --
-	; longer than 16. This is a sharp cutoff.
-	; This causes parser to run at O(N^3) for LEN < 16 and
-	; a faster rate, O(N^2.3) for 16<LEN. This should help.
-	; Otherwise, assign modification to scorer depending on
-	; mst-parsing mode. If mst-distance accounting is activated
-	; shift all mi-values by 1/LEN, where LEN is the difference
-	; in positions in a sentence between words in word-pair.
-	(define (trunc-scorer LW RW LEN)
-		(if (< 16 LEN)
-			-2e25
-			(let
-				((modifier (if mst-dist (/ 1 LEN) 0)))
-				(+ modifier (scorer LW RW LEN)))))
+	(define dist-scorer (make-distance-scorer scorer DIST-MULT))
 
 	; Process the list of words.
-	(mst-parse-atom-seq word-list trunc-scorer)
+	(mst-parse-atom-seq word-list dist-scorer)
 )
 
 ; wrapper for backwards compatibility
@@ -145,7 +137,7 @@
 	(mst-parse-text-mode plain-text "any" #f))
 
 ; ---------------------------------------------------------------------
-(define (export-mst-parse plain-text mstparse SENT-NBR filename)
+(define (export-mst-parse plain-text mstparse filename)
 "
   Export an MST-parse to a text file named filename,
   so that parses can be examined.
@@ -186,11 +178,10 @@
 		(lambda (l1 l2)
 			(< (get-lindex l1) (get-lindex l2))))
 
-	; Print the numbered sentence first
+	; Print the sentence first
 	(if (not (null? plain-text))
 		(display
-			(format #f "~a\t~a\t"
-				SENT-NBR
+			(format #f "~a\n"
 				plain-text)
 			file-port))
 
@@ -199,7 +190,7 @@
 		(lambda (l) ; links
 			(if (> (get-mi l) -1.0e10) ; bad-MI
 				(display
-					(format #f "~a ~a ~a ~a ~a\t"
+					(format #f "~a ~a ~a ~a ~a\n"
 						(get-lindex l)
 						(get-lword l)
 						(get-rindex l)
@@ -215,13 +206,13 @@
 	(close-port file-port)
 )
 
-(define-public (observe-mst-mode plain-text SENT-NBR CNT-MODE MST-DIST EXPORT-MST)
+(define-public (observe-mst-mode plain-text CNT-MODE MST-DIST EXPORT-MST)
 "
   observe-mst-mode -- update pseduo-disjunct counts by observing raw text.
   
   Build mst-parses using MI calculated beforehand.
-  When MST-DIST is true, word-pair MI values are adjusted for distance.
-  Obtained parses are exported to file named EXPORT-MST, unless EXPORT-MST is #f.
+  Values in MST-DIST adjust word-pair weight values for distance.
+  Obtained parses are exported to file if EXPORT-MST is true.
   This is the second part of the learning algo: simply count how
   often pseudo-disjuncts show up.
 "
@@ -241,14 +232,14 @@
 	)
 	(if (not (equal? EXPORT-MST "#f"))
 		(if file-cnt-mode
-			(export-mst-parse (car (string-split plain-text #\newline)) parse SENT-NBR EXPORT-MST)
-			(export-mst-parse plain-text parse SENT-NBR EXPORT-MST)
+			(export-mst-parse (car (string-split plain-text #\newline)) parse EXPORT-MST)
+			(export-mst-parse plain-text parse EXPORT-MST)
 		)
 	)
-	parse ; return the parse
+	parse; return the parse, for unit-test purposes
 )
 
 ; Wrapper for backwards compatibility
 (define-public (observe-mst plain-text)
-	(observe-mst-mode plain-text "any" 1 #f "#f")
+	(observe-mst-mode plain-text "any" #f "#f")
 )

--- a/run-poc/redefine-mst-parser.scm
+++ b/run-poc/redefine-mst-parser.scm
@@ -6,25 +6,7 @@
 ; A list of word-pairs, together with the associated mutual information,
 ; is returned.
 ;
-
-; Create a distance-modified scorer function:
-; The list DIST-MULTS contains multipliers for the score for each
-; possible integer distance between the atoms. For distances longer 
-; than the range of the list, the list's last value is used as multiplier.
-; Also: assign a bad cost to links that are too long --
-; longer than 16. This is a sharp cutoff.
-; This causes parser to run at O(N^3) for LEN < 16 and
-; a faster rate, O(N^2.3) for 16<LEN. This should help.
-(define (make-distance-scorer scorer DIST-MULTS)
-	(lambda (LW RW LEN)
-		; take distance-multiplier from DIST-MULT list
-		(define multiplier (list-ref DIST-MULTS (- (min LEN (length DIST-MULTS)) 1)))
-
-		(if (< 16 LEN) -2e25 (* multiplier (scorer LW RW LEN)))
-	)
-)
-
-(define-public (mst-parse-text-file plain-textblock DIST-MULT)
+(define-public (mst-parse-text-file plain-textblock mst-dist)
 "
 	Procedure to MST-parse sentences coming from an instance-pair weight file.
 "
@@ -85,7 +67,7 @@
 	)	
 
 	; Define scoring function to look for values in weights-array.
-	; Scorer lambda function should refer to weights-array from its
+	; Scorer lambda function should store weights-array from its
 	; current environment (array was defined above).
 	(define scorer 
 		(lambda (left-atom right-atom distance)
@@ -96,15 +78,28 @@
 		)
 	)
 
-	(define dist-scorer (make-distance-scorer scorer DIST-MULT))
+	; Assign a bad cost to links that are too long --
+	; longer than 16. This is a sharp cutoff.
+	; This causes parser to run at O(N^3) for LEN < 16 and
+	; a faster rate, O(N^2.3) for 16<LEN. This should help.
+	; Otherwise, assign modification to scorer depending on
+	; mst-parsing mode. If mst-distance accounting is activated
+	; shift all mi-values by 1/LEN, where LEN is the difference
+	; in positions in a sentence between words in word-pair.
+	(define (trunc-scorer LW RW LEN)
+		(if (< 16 LEN)
+			-2e25
+			(let
+				((modifier (if mst-dist (/ 1 LEN) 0)))
+				(+ modifier (scorer LW RW LEN)))))
 
 	; Entry point, call parser on atomized sentence with ad-hoc scorer
-	(mst-parse-atom-seq (word-list (word-strs current-sentence)) dist-scorer)
+	(mst-parse-atom-seq (word-list (word-strs current-sentence)) trunc-scorer)
 
 )
 
 
-(define-public (mst-parse-text-mode plain-text cnt-mode DIST-MULT)
+(define-public (mst-parse-text-mode plain-text cnt-mode mst-dist)
 
 	; Assuming input is tokenized, this procedure separates by spaces 
 	; and adds LEFT-WALL
@@ -126,10 +121,23 @@
 
 	(define scorer (make-score-fn mi-source 'pair-fmi))
 
-	(define dist-scorer (make-distance-scorer scorer DIST-MULT))
+	; Assign a bad cost to links that are too long --
+	; longer than 16. This is a sharp cutoff.
+	; This causes parser to run at O(N^3) for LEN < 16 and
+	; a faster rate, O(N^2.3) for 16<LEN. This should help.
+	; Otherwise, assign modification to scorer depending on
+	; mst-parsing mode. If mst-distance accounting is activated
+	; shift all mi-values by 1/LEN, where LEN is the difference
+	; in positions in a sentence between words in word-pair.
+	(define (trunc-scorer LW RW LEN)
+		(if (< 16 LEN)
+			-2e25
+			(let
+				((modifier (if mst-dist (/ 1 LEN) 0)))
+				(+ modifier (scorer LW RW LEN)))))
 
 	; Process the list of words.
-	(mst-parse-atom-seq word-list dist-scorer)
+	(mst-parse-atom-seq word-list trunc-scorer)
 )
 
 ; wrapper for backwards compatibility
@@ -137,7 +145,7 @@
 	(mst-parse-text-mode plain-text "any" #f))
 
 ; ---------------------------------------------------------------------
-(define (export-mst-parse plain-text mstparse filename)
+(define (export-mst-parse plain-text mstparse SENT-NBR filename)
 "
   Export an MST-parse to a text file named filename,
   so that parses can be examined.
@@ -178,10 +186,11 @@
 		(lambda (l1 l2)
 			(< (get-lindex l1) (get-lindex l2))))
 
-	; Print the sentence first
+	; Print the numbered sentence first
 	(if (not (null? plain-text))
 		(display
-			(format #f "~a\n"
+			(format #f "~a\t~a\t"
+				SENT-NBR
 				plain-text)
 			file-port))
 
@@ -190,7 +199,7 @@
 		(lambda (l) ; links
 			(if (> (get-mi l) -1.0e10) ; bad-MI
 				(display
-					(format #f "~a ~a ~a ~a ~a\n"
+					(format #f "~a ~a ~a ~a ~a\t"
 						(get-lindex l)
 						(get-lword l)
 						(get-rindex l)
@@ -206,13 +215,13 @@
 	(close-port file-port)
 )
 
-(define-public (observe-mst-mode plain-text CNT-MODE MST-DIST EXPORT-MST)
+(define-public (observe-mst-mode plain-text SENT-NBR CNT-MODE MST-DIST EXPORT-MST)
 "
   observe-mst-mode -- update pseduo-disjunct counts by observing raw text.
   
   Build mst-parses using MI calculated beforehand.
-  Values in MST-DIST adjust word-pair weight values for distance.
-  Obtained parses are exported to file if EXPORT-MST is true.
+  When MST-DIST is true, word-pair MI values are adjusted for distance.
+  Obtained parses are exported to file named EXPORT-MST, unless EXPORT-MST is #f.
   This is the second part of the learning algo: simply count how
   often pseudo-disjuncts show up.
 "
@@ -230,17 +239,16 @@
 		(lambda (dj) (if (not (is-oversize? dj)) (count-one-atom dj)))
 		(make-sections parse)
 	)
-	(if EXPORT-MST
+	(if (not (equal? EXPORT-MST "#f"))
 		(if file-cnt-mode
-			(export-mst-parse (car (string-split plain-text #\newline)) parse "mst-parses.ull")
-			(export-mst-parse plain-text parse "mst-parses.ull")
+			(export-mst-parse (car (string-split plain-text #\newline)) parse SENT-NBR EXPORT-MST)
+			(export-mst-parse plain-text parse SENT-NBR EXPORT-MST)
 		)
 	)
-
-	parse; return the parse, for unit-test purposes
+	parse ; return the parse
 )
 
 ; Wrapper for backwards compatibility
 (define-public (observe-mst plain-text)
-	(observe-mst-mode plain-text "any" #f #f)
+	(observe-mst-mode plain-text "any" 1 #f "#f")
 )

--- a/run-poc/submit-one.pl
+++ b/run-poc/submit-one.pl
@@ -79,9 +79,9 @@ if ($ARGV[3] eq "file")
 		if (/^\n$/) {
 			chomp($buffer);
 			open NC, $netcat || die "nc failed: $!\n";
-			print NC "($ARGV[2] \"$buffer\" \"$ARGV[3]\" '(@dist_mult) $ARGV[5])\n";
+			print NC "($ARGV[2] \"$buffer\" \"$ARGV[3]\" '(@dist_mult) \"$ARGV[5]\")\n";
 			# $sent_nbr += 1;
-			# send_stuff("($ARGV[2] \"$buffer\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n");
+			# send_stuff("($ARGV[2] \"$buffer\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] \"$ARGV[5]\")\n");
 			my $elapsed = time() - $start_time;
 			print "submit-one (elapsed $elapsed): $_\n";
 			$buffer="";
@@ -107,9 +107,9 @@ else
  			# print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"; }
 			#{ send_stuff("($ARGV[2] \"$_\" \"$ARGV[3]\" $ARGV[4])\n"); }
 		elsif ( $ARGV[2] eq "observe-mst-mode" )
-			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" '(@dist_mult) $ARGV[5])\n"; }
+			{ print NC "($ARGV[2] \"$_\" \"$ARGV[3]\" '(@dist_mult) \"$ARGV[5]\")\n"; }
 			#{ $sent_nbr += 1;
-			#send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] $ARGV[5])\n"); }
+			#send_stuff("($ARGV[2] \"$_\" \"$sent_nbr\" \"$ARGV[3]\" $ARGV[4] \"$ARGV[5]\")\n"); }
 		my $elapsed = time() - $start_time;
 		print "submit-one (elapsed $elapsed): $_\n";
 	}

--- a/tests/MST-parse-test.scm
+++ b/tests/MST-parse-test.scm
@@ -65,8 +65,8 @@
 )
 
 ; Parse the sentences
-(define parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult #f))
-(define parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult #f))
+(define parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult "#f"))
+(define parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult "#f"))
 
 ; manually calculated, expected parses
 (define w1 (cons 1 (WordNode "###LEFT-WALL###")))
@@ -117,8 +117,8 @@
 )
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult #f))
-(set! parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult #f))
+(set! parse-1 (observe-mst-mode test-str-1 cnt-mode dist-mult "#f"))
+(set! parse-2 (observe-mst-mode test-str-2 cnt-mode dist-mult "#f"))
 
 ; manually calculated, expected parses
 (set! w3 (cons 3 (WordNode "first")))
@@ -170,7 +170,7 @@
 3 file 4 mode 2")
 
 ; Parse the sentences
-(set! parse-1 (observe-mst-mode text-block cnt-mode dist-mult #f))
+(set! parse-1 (observe-mst-mode text-block cnt-mode dist-mult "#f"))
 
 ; Manually calculated, expected parses (note that current heuristic doesn't
 ; give us the actual MST parse, but a close one).
@@ -202,7 +202,7 @@
 (set! dist-mult '(1 0.5))
 
 ; Parse the sentences
-(set! parse-2 (observe-mst-mode text-block cnt-mode dist-mult #f))
+(set! parse-2 (observe-mst-mode text-block cnt-mode dist-mult "#f"))
 
 ; Manually calculated, expected parses
 (define expected-parse-2


### PR DESCRIPTION
Replaced generic parses filename by user-specified parameter in MST-parser